### PR TITLE
Update to nimble_parsec 0.5 and makeup 0.6

### DIFF
--- a/lib/makeup/lexers/elixir_lexer.ex
+++ b/lib/makeup/lexers/elixir_lexer.ex
@@ -347,7 +347,7 @@ defmodule Makeup.Lexers.ElixirLexer do
     |> concat(token(">", :punctuation))
 
   line =
-    repeat_until(utf8_string([], 1), [ascii_char([?\n])])
+    repeat(lookahead_not(ascii_char([?\n])) |> utf8_string([], 1))
 
   inline_comment =
     string("#")

--- a/lib/makeup/lexers/elixir_lexer/helper.ex
+++ b/lib/makeup/lexers/elixir_lexer/helper.ex
@@ -22,10 +22,10 @@ defmodule Makeup.Lexers.ElixirLexer.Helper do
     choices = middle ++ [utf8_char([])]
 
     left
-    |> repeat_until(choice(choices), [right])
+    |> repeat(lookahead_not(right) |> choice(choices))
     |> concat(right)
     |> optional(utf8_string([?a..?z, ?A..?Z], min: 1))
-    |> traverse({Combinators, :collect_raw_chars_and_binaries, [ttype, attrs]})
+    |> post_traverse({Combinators, :collect_raw_chars_and_binaries, [ttype, attrs]})
   end
 
   def escaped(literal) when is_binary(literal) do

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule MakeupElixir.Mixfile do
   use Mix.Project
 
-  @version "0.10.0"
+  @version "0.11.0"
   @url "https://github.com/tmbb/makeup_elixir"
 
   def project do
@@ -50,7 +50,7 @@ defmodule MakeupElixir.Mixfile do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:makeup, "~> 0.5.5"},
+      {:makeup, "~> 0.6"},
       {:benchee, "~> 0.13", only: [:dev, :test]}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -10,5 +10,5 @@
   "jason": {:hex, :jason, "1.0.0", "0f7cfa9bdb23fed721ec05419bcee2b2c21a77e926bce0deda029b5adc716fe2", [:mix], [{:decimal, "~> 1.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm"},
   "makeup": {:hex, :makeup, "0.5.5", "9e08dfc45280c5684d771ad58159f718a7b5788596099bdfb0284597d368a882", [:mix], [{:nimble_parsec, "~> 0.4", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.8.0", "1204a2f5b4f181775a0e456154830524cf2207cf4f9112215c05e0b76e4eca8b", [:mix], [{:makeup, "~> 0.5.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.4.0", "ee261bb53214943679422be70f1658fff573c5d0b0a1ecd0f18738944f818efe", [:mix], [], "hexpm"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
 }


### PR DESCRIPTION
Updates to `nimble_parsec` 0.5 and `makeup` 0.6.  Note that this PR references `{:makeup, "~> 0.6"}` which of course won't exist until that package is published.